### PR TITLE
登録データの参照機能の実装

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="deploymentTargetDropDown">
-    <runningDeviceTargetSelectedWithDropDown>
+    <targetSelectedWithDropDown>
       <Target>
-        <type value="RUNNING_DEVICE_TARGET" />
+        <type value="QUICK_BOOT_TARGET" />
         <deviceKey>
           <Key>
             <type value="VIRTUAL_DEVICE_PATH" />
@@ -11,7 +11,7 @@
           </Key>
         </deviceKey>
       </Target>
-    </runningDeviceTargetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2024-07-25T06:04:08.862850100Z" />
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2024-07-30T06:23:50.783415Z" />
   </component>
 </project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.EmployeeApp"
         tools:targetApi="31">
+        <activity android:name=".EmployeeDetailActivity" />
         <activity
             android:name=".MainActivity"
             android:exported="true">

--- a/app/src/main/java/com/example/employeeapp/EmployeeAdapter.kt
+++ b/app/src/main/java/com/example/employeeapp/EmployeeAdapter.kt
@@ -7,18 +7,24 @@ import android.view.ViewGroup
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 
-class EmployeeAdapter : RecyclerView.Adapter<EmployeeAdapter.EmployeeViewHolder>() {
+class EmployeeAdapter(private val onItemClick: (String) -> Unit) : RecyclerView.Adapter<EmployeeAdapter.EmployeeViewHolder>(){
     private var employees = emptyList<Employee>()
+
     /** リストアイテムのビューの保持(TextViewから参照) **/
-    class EmployeeViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+    class EmployeeViewHolder(itemView: View, private val onItemClick: (String) -> Unit) : RecyclerView.ViewHolder(itemView) {
         val idholder: TextView = itemView.findViewById(R.id.idholder)
         val firstName: TextView = itemView.findViewById(R.id.firstName)
-    }
 
+        init {
+            itemView.setOnClickListener {
+                onItemClick(idholder.text.toString())
+            }
+        }
+    }
     /** インフレートして新しいViewを返す **/
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): EmployeeViewHolder {
         val itemView = LayoutInflater.from(parent.context).inflate(R.layout.list_item_employee, parent, false)
-        return EmployeeViewHolder(itemView)
+        return EmployeeViewHolder(itemView, onItemClick)
     }
     /** 特定の位置のデータをViewにバインドする **/
     override fun onBindViewHolder(holder: EmployeeViewHolder, position: Int) {
@@ -28,7 +34,6 @@ class EmployeeAdapter : RecyclerView.Adapter<EmployeeAdapter.EmployeeViewHolder>
     }
     /** リスト内のアイテム数を取得 **/
     override fun getItemCount() = employees.size
-
     /** RecycleViewの更新をして再描画 **/
     internal fun setEmployees(employees: List<Employee>) {
         this.employees = employees

--- a/app/src/main/java/com/example/employeeapp/EmployeeDetail.kt
+++ b/app/src/main/java/com/example/employeeapp/EmployeeDetail.kt
@@ -1,0 +1,65 @@
+package com.example.employeeapp
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
+import androidx.activity.viewModels
+
+class EmployeeDetailActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_employee_detail)
+
+        val employeeId = intent.getStringExtra(EXTRA_EMPLOYEE_ID) ?: return
+
+        // Viewの参照を取得
+        val idTextView: TextView = findViewById(R.id.detail_employee_id)
+        val firstNameTextView: TextView = findViewById(R.id.detail_first_name)
+        val secondNameTextView: TextView = findViewById(R.id.detail_second_name)
+        val sectionTextView: TextView = findViewById(R.id.detail_section)
+        val emailTextView: TextView = findViewById(R.id.detail_email)
+        val genderTextView: TextView = findViewById(R.id.detail_gender)
+
+        // ViewModelのインスタンスを取得して、指定したIDの社員情報を取得
+        val employeeViewModel: EmployeeViewModel by viewModels()
+
+        employeeViewModel.getEmployeeById(employeeId) { employee ->
+            employee?.let {
+                idTextView.text = it.idholder
+                firstNameTextView.text = it.firstName
+                secondNameTextView.text = it.secondName
+                sectionTextView.text = when (it.sectionItem) {
+                    1 -> "シス開"
+                    2 -> "ビジソル"
+                    else -> "グロカル"
+                }
+                emailTextView.text = it.editTextText
+                genderTextView.text = when (it.radioGroup){
+                    1 -> "男性"
+                    else -> "女性"
+                }
+
+            }
+        }
+
+        // "戻る"ボタンの参照を取得
+        val backButton: Button = findViewById(R.id.backbtn)
+        backButton.setOnClickListener {
+            // EmployeeListFragmentに遷移する
+            val fragment = EmployeeListFragment()
+            supportFragmentManager.beginTransaction()
+                .replace(R.id.fragment_container, fragment)
+                .commit()
+        }
+    }
+
+
+    companion object {
+        const val EXTRA_EMPLOYEE_ID = "com.example.employeeapp.EMPLOYEE_ID"
+    }
+}

--- a/app/src/main/java/com/example/employeeapp/EmployeeListFragment.kt
+++ b/app/src/main/java/com/example/employeeapp/EmployeeListFragment.kt
@@ -1,5 +1,6 @@
 package com.example.employeeapp
 
+import android.content.Intent
 import android.graphics.Rect
 import android.os.Bundle
 import android.util.Log
@@ -20,46 +21,37 @@ class EmployeeListFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        // フラグメントのレイアウトをインフレート
         return inflater.inflate(R.layout.fragment_employee_list, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        // RecyclerView の設定
         val recyclerView = view.findViewById<RecyclerView>(R.id.recycler_view)
-        val adapter = EmployeeAdapter()
+        val adapter = EmployeeAdapter { employeeId ->
+            val intent = Intent(activity, EmployeeDetailActivity::class.java).apply {
+                putExtra(EmployeeDetailActivity.EXTRA_EMPLOYEE_ID, employeeId)
+            }
+            startActivity(intent)
+        }
         recyclerView.adapter = adapter
         recyclerView.layoutManager = LinearLayoutManager(context)
 
-        val spacingInPixels = resources.getDimensionPixelSize(R.dimen.item_spacing)  // res/values/dimens.xml で定義した値を取得
-        recyclerView.addItemDecoration(CustomItemDecoration(spacingInPixels))
+        val spacingInPixels = resources.getDimensionPixelSize(R.dimen.item_spacing)
+        recyclerView.addItemDecoration(EmployeeListFragment.CustomItemDecoration(spacingInPixels))
 
-//        // 初期データの追加（テスト用）
-//        employeeViewModel.insert(Employee(
-//            idholder = "123",
-//            firstName = "John",
-//            secondName = "Doe",
-//            sectionItem = 1,
-//            editTextText = "john.doe@example.com",
-//            radioGroup = 1
-//        ))
-
-// ViewModel からデータを取得して RecyclerView に表示
         employeeViewModel.getAllEmployees { employees ->
             adapter.setEmployees(employees)
         }
     }
+
     class CustomItemDecoration(private val spacing: Int) : RecyclerView.ItemDecoration() {
         override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
             super.getItemOffsets(outRect, view, parent, state)
-
-            // アイテムの上下左右にスペースを追加
             outRect.left = spacing
             outRect.right = spacing
-            outRect.top = spacing / 2  // 上下の隙間を狭くする
-            outRect.bottom = spacing / 2  // 上下の隙間を狭くする
+            outRect.top = spacing / 2
+            outRect.bottom = spacing / 2
         }
     }
 }

--- a/app/src/main/java/com/example/employeeapp/EmployeeRepository.kt
+++ b/app/src/main/java/com/example/employeeapp/EmployeeRepository.kt
@@ -10,4 +10,7 @@ class EmployeeRepository (private val employeeDao: EmployeeDao){
     suspend fun insert(employee: Employee) {
         employeeDao.insert(employee)
     }
+    suspend fun getEmployeeById(employeeId: String): Employee? {
+        return employeeDao.getEmployeeById(employeeId)
+    }
 }

--- a/app/src/main/java/com/example/employeeapp/EmployeeViewModel.kt
+++ b/app/src/main/java/com/example/employeeapp/EmployeeViewModel.kt
@@ -21,7 +21,14 @@ class EmployeeViewModel (application: Application) : AndroidViewModel(applicatio
             }
         }
     }
-
+    fun getEmployeeById(employeeId: String, callback: (Employee?) -> Unit) {
+        viewModelScope.launch(Dispatchers.IO) {
+            val employee = repository.getEmployeeById(employeeId)
+            withContext(Dispatchers.Main) {
+                callback(employee)
+            }
+        }
+    }
     fun insert(employee: Employee) = viewModelScope.launch(Dispatchers.IO) {
         repository.insert(employee)
     }

--- a/app/src/main/res/layout/activity_employee_detail.xml
+++ b/app/src/main/res/layout/activity_employee_detail.xml
@@ -1,0 +1,155 @@
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:backgroundTint="#4CAF50"
+    tools:context=".MainActivity">
+
+    <include
+        android:id="@+id/toolbar"
+        layout="@layout/detail_toolbar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+
+    <ScrollView
+        android:id="@+id/scrollView"
+        android:layout_width="356dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:isScrollContainer="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar">
+
+        <LinearLayout
+            android:id="@+id/LinearLayout"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:orientation="vertical">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="292dp">
+
+                <TextView
+                    android:id="@+id/detail_employee_id"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="80dp"
+                    android:layout_marginTop="16dp"
+                    android:text="ID:"
+                    app:layout_constraintStart_toEndOf="@+id/employeeID"
+                    app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+
+                <TextView
+                    android:id="@+id/employeeID"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="52dp"
+                    android:layout_marginTop="16dp"
+                    android:text="@string/employee_id"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/toolbar" />
+
+                <TextView
+                    android:id="@+id/employeeName"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="52dp"
+                    android:layout_marginTop="36dp"
+                    android:text="@string/employee_name"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/employeeID" />
+
+
+                <TextView
+                    android:id="@+id/detail_first_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="80dp"
+                    android:layout_marginTop="40dp"
+                    android:text="First Name:"
+                    app:layout_constraintStart_toEndOf="@+id/employeeName"
+                    app:layout_constraintTop_toBottomOf="@+id/detail_employee_id" />
+
+
+                <TextView
+                    android:id="@+id/detail_second_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    android:layout_marginTop="40dp"
+                    android:text="Second Name:"
+                    app:layout_constraintStart_toEndOf="@+id/detail_first_name"
+                    app:layout_constraintTop_toBottomOf="@+id/detail_employee_id" />
+
+                <TextView
+                    android:id="@+id/sectionHolder"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="52dp"
+                    android:layout_marginTop="40dp"
+                    android:text="@string/employee_sec"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/employeeName" />
+
+                <TextView
+                    android:id="@+id/detail_section"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginTop="40dp"
+                    android:text="Section:"
+                    app:layout_constraintStart_toEndOf="@+id/sectionHolder"
+                    app:layout_constraintTop_toBottomOf="@+id/detail_first_name" />
+
+                <TextView
+                    android:id="@+id/textView5"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="52dp"
+                    android:layout_marginTop="40dp"
+                    android:text="@string/employee_email"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/sectionHolder" />
+
+                <TextView
+                    android:id="@+id/detail_email"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginTop="40dp"
+                    android:text="Email:"
+                    app:layout_constraintStart_toEndOf="@+id/textView5"
+                    app:layout_constraintTop_toBottomOf="@+id/detail_section" />
+
+                <TextView
+                    android:id="@+id/gender"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="52dp"
+                    android:layout_marginTop="40dp"
+                    android:layout_weight="0"
+                    android:text="@string/employee_gender"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@+id/textView5" />
+
+                <TextView
+                    android:id="@+id/detail_gender"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="90dp"
+                    android:layout_marginTop="40dp"
+                    android:text="Gender:"
+                    app:layout_constraintStart_toEndOf="@+id/gender"
+                    app:layout_constraintTop_toBottomOf="@+id/detail_email" />
+            </androidx.constraintlayout.widget.ConstraintLayout>
+        </LinearLayout>
+    </ScrollView>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/detail_toolbar.xml
+++ b/app/src/main/res/layout/detail_toolbar.xml
@@ -1,0 +1,30 @@
+<androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="?attr/actionBarSize"
+    android:background="#009688"
+    android:theme="@style/ThemeOverlay.AppCompat.ActionBar"
+    android:paddingStart="0dp"
+    android:paddingLeft="0dp"
+    android:paddingEnd="0dp"
+    android:paddingRight="0dp">
+
+    <Button
+        android:id="@+id/backbtn"
+        android:layout_width="100dp"
+        android:layout_height="wrap_content"
+        android:backgroundTint="#009688"
+        android:text="@string/back_btn"
+        android:textSize="30px" />
+
+    <TextView
+        android:id="@+id/toolbar_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/employee_detail"
+        android:textColor="@android:color/white"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+</androidx.appcompat.widget.Toolbar>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="app_name">社員管理App</string>
     <string name="employee_list">社員一覧</string>
     <string name="employee_register">社員登録</string>
+    <string name="employee_detail">社員参照</string>
     <string name="employee_id">社員ID</string>
     <string name="employee_name">社員名</string>
     <string name="employee_sec">所属セクション</string>


### PR DESCRIPTION
##やったこと
・社員一覧画面の社員ID押下時、社員参照画面に遷移するよう実装
・idから登録されている社員情報を取得し、社員参照画面で社員ID、社員名、所属セクション、メールアドレス、性別を表示
・戻るボタンを実装し、社員参照画面から社員一覧画面に遷移するよう実装

##動作確認
・Pixcel_3a,Nexus9で動作確認、テスト実施済み